### PR TITLE
Re-fetch user after saving

### DIFF
--- a/app/JobApp/ViewModels/UserViewModel.swift
+++ b/app/JobApp/ViewModels/UserViewModel.swift
@@ -62,7 +62,8 @@ class UserViewModel<
 		Task {
 			do {
 				if let userId {
-					setUser(try await userService.updateUser(User(id: userId, template: template)))
+					_ = try await userService.updateUser(User(id: userId, template: template))
+					setUser(try await userService.getUser(withId: userId))
 				} else {
 					setUser(try await userService.createUser(from: template))
 				}


### PR DESCRIPTION
This ensures job applications are up to date, since the update endpoint doesn't return them
